### PR TITLE
fix reference to yaml-json-file-dir input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,5 +25,5 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.json-schema-file }}
-    - ${{ inputs.yaml-file-dir }}
+    - ${{ inputs.yaml-json-file-dir }}
     - ${{ inputs.recursive }}


### PR DESCRIPTION
The action.yml file is not referencing the defined input.